### PR TITLE
agregar simulador

### DIFF
--- a/KahootClient.go
+++ b/KahootClient.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"github.com/gorilla/websocket"
+	"log"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type KahootClient struct {
+	conn   *websocket.Conn
+	pin    int
+	userId int
+}
+
+func newKahootClient(userId int, pin int) *KahootClient {
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:5000/ws", nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	kc := KahootClient{conn, pin, userId}
+	//kc.conn.WriteMessage(websocket.TextMessage, []byte("Player "+strconv.Itoa(kc.userId)+" entered the room."))
+	return &kc
+}
+
+func (kc *KahootClient) playTrivia(n int, timeout int) {
+	// este es un metodo generico para trivias
+	// elige un entero entre 0 y n-1 y lo envia por el ws luego de una sleep aleatorio de timeout seg
+	ans := strconv.Itoa(rand.Intn(n))
+	time.Sleep(time.Duration(rand.Intn(timeout*1000)) * time.Millisecond)
+	kc.conn.WriteMessage(websocket.TextMessage, []byte("Player "+strconv.Itoa(kc.userId)+": "+ans))
+}
+
+func (kc *KahootClient) playMultipleChoice(timeout int) {
+	// multiple choice son 4 opciones
+	kc.playTrivia(4, timeout)
+}
+
+func (kc *KahootClient) playTrueOrFalse(timeout int) {
+	// true = 0, false = 1
+	kc.playTrivia(2, timeout)
+}
+
+func (kc *KahootClient) endGame() {
+	// cuando finaliza el juego, cierra el ws
+	kc.conn.WriteMessage(websocket.TextMessage, []byte("Player "+strconv.Itoa(kc.userId)+": I don't wanna go Mr. Stark!"))
+	kc.conn.Close()
+}
+
+func (kc *KahootClient) play(wg *sync.WaitGroup) {
+	defer wg.Done()
+	// loop de juego
+	for {
+		// esperar broadcast
+		// TODO: buscar una mejor manera para esperar broadcast
+		_, message, err := kc.conn.ReadMessage()
+		if err != nil {
+			log.Println("read:", err)
+			return
+		}
+
+		// TODO: buscar en los headers los parametros de la pregunta
+		// seleccionar tipo y responder
+		switch {
+		case strings.Contains(string(message), "multiple_choice"):
+			kc.playMultipleChoice(5)
+
+		case strings.Contains(string(message), "true_or_false"):
+			kc.playTrueOrFalse(5)
+
+		case strings.Contains(string(message), "endgame"):
+			kc.endGame()
+			return
+
+		default:
+			//log.Printf("recv: %s", message)
+		}
+	}
+
+	log.Println("bye!")
+
+	//
+
+	return
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"sync"
+)
+
+func main() {
+	n := flag.Int("n", 1, "number of simulated clients")
+	pin := flag.Int("pin", 1234, "kahoot game pin")
+
+	flag.Parse()
+
+	log.Println("Simulated clients: ", *n)
+	log.Println("Room PIN: ", *pin)
+
+	clients := make([]*KahootClient, *n)
+	var wg sync.WaitGroup
+
+	// instanciar a los clientes e ingresar a la sala
+	log.Println("Initializing clients...")
+	for i, _ := range clients {
+		wg.Add(1)
+		go func(i int) {
+			kc := newKahootClient(i, *pin)
+			clients[i] = kc
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	log.Println("Let the game begin!")
+	// jugar
+	for _, kc := range clients {
+		wg.Add(1)
+		go kc.play(&wg)
+	}
+	wg.Wait()
+
+	// TODO: stats
+
+}


### PR DESCRIPTION
agrego una primera version del simulador:
para correrlo con  `go run *.go`
```
Usage
  -n int
    	number of simulated clients (default 1)
  -pin int
    	kahoot game pin (default 1234)
```
- crea n instancias de KahootClient que se conectan por ws a localhost:5000/ws
- el metodo play de KahootClient, queda a la espera de algun mensaje y si recibe, en este caso "true_or_false"/"multiple_choice", envía una respuesta aleatoria luego de un intervalo aleatorio
- tanto la creación como el juego se hace con goroutines